### PR TITLE
Reject single-block reorgs to prevent uncle maker attack

### DIFF
--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -88,6 +88,13 @@ func (f *ForkChoice) ReorgNeeded(current *types.Header, header *types.Header) (b
 	if ttd := f.chain.Config().TerminalTotalDifficulty; ttd != nil && ttd.Cmp(externTd) <= 0 {
 		return true, nil
 	}
+
+	if current.Number.Cmp(header.Number) == 0 {
+		// Reject single-block reorgs to mitigate uncle maker attack.
+		// Refer to https://eprint.iacr.org/2022/1020 for more info.
+		return false, nil
+	}
+	
 	// If the total difficulty is higher than our known, add it to the canonical chain
 	// Second clause in the if statement reduces the vulnerability to selfish mining.
 	// Please refer to http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf


### PR DESCRIPTION
This will reject single-block reorgs and prevent the uncle maker attack which is actively being exploited on octa network

Original Flexpool PR and more details:
https://github.com/ethereum/go-ethereum/pull/25493